### PR TITLE
Include middle name in title slide if provided.

### DIFF
--- a/templates/slim/slide_title.html.slim
+++ b/templates/slim/slide_title.html.slim
@@ -22,6 +22,8 @@ section.title id=header.id class=[role, ('image' if _bg_img)] style=_style data-
         p.author
           span.personname
             span.firstname=>attr :firstname
+            - if (attr? :middlename)
+              span.middlename=>attr :middlename
             span.surname=attr :lastname
           - if (attr? :position) || (attr? :organization)
             =newline


### PR DESCRIPTION
Some people write their names with a middle name or middle initial.  For example, “brian m. carlson” or “Dwight D. Eisenhower”.  Presumably, if they put that name in their presentation source, they wanted it to appear that way on the title slide, so include the middle name if it's provided.

I tested that the title slide renders correctly both with and without a middle initial.
