### PR TITLE
add support for named route hashes with bespoke-hash

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -348,6 +348,16 @@ A shorthand for the conceal option is to prefix the section title with a `!`.
 image::chart.svg[]
 ----
 
+You can also add a named hash to have a URL like `/#intro`
+instead of `/#3`
+
+.A slide with a named route
+[source,asciidoc]
+----
+[hash="intro"]
+= Intro
+----
+
 Notice how we're keeping the concerns of content and presentation cleanly separated.
 Using very little AsciiDoc, you're able to describe a lot of different functionality.
 There doesn't even have to be a direct, literal mapping between the AsciiDoc and the HTML.

--- a/templates/slim/section.html.slim
+++ b/templates/slim/section.html.slim
@@ -9,7 +9,7 @@
 - _style = nil
 - if (_bg_img = pluck_first context: :image, role: 'canvas')
   - _style = %[background-image: url(#{image_uri _bg_img.attr(:target)}); background-size: #{(_bg_img.roles & %w[cover contain])[0] || 'cover'}; background-repeat: no-repeat]
-section id=_id class=[*_roles, ('image' if _bg_img)] style=_style data-title=(local_attr :reftext) data-bespoke-backdrop=(local_attr 'backdrop-role')
+section id=_id class=[*_roles, ('image' if _bg_img)] style=_style data-title=(local_attr :reftext) data-bespoke-backdrop=(local_attr 'backdrop-role') data-bespoke-hash=(local_attr :hash)
   - content_for :content
     - unless (_title.start_with? '!') || (option? :conceal)
       - if (_title_obj = partition_title _title).subtitle?


### PR DESCRIPTION
Naive (and untested) attempt to add the support of named routes.
I _assume_ it should be something like this, but I've got to admit I don't know a thing about Ruby or slim... This is more to get the ball rolling  😊

Fixes #9 
